### PR TITLE
Make code C99-compliant

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 
 CC	= gcc
 #OPT	= -Wall -O3 -fopenmp -DSO3_VERSION=\"0.1\" -DSO3_BUILD=\"`git rev-parse HEAD`\"
-OPT	= -Wall -g -fopenmp -DSO3_VERSION=\"1.1b1\" -DSO3_BUILD=\"`git rev-parse HEAD`\"
+OPT	= -std=c99 -pedantic -W -Wall -Wmissing-prototypes -Wstrict-prototypes -g -fopenmp -O3 -DSO3_VERSION=\"1.1b1\" -DSO3_BUILD=\"`git rev-parse HEAD`\"
 
 
 # ======== LINKS ========

--- a/src/c/so3_about.c
+++ b/src/c/so3_about.c
@@ -15,7 +15,7 @@
 
 #include <stdio.h>
 
-int main(int argc, char *argv[]) {
+int main(void) {
 
   printf("%s\n", "===================================================================");
   printf("%s\n", "SO3 package to perform Wigner transform on the rotation group SO(3)");

--- a/src/c/so3_core.c
+++ b/src/c/so3_core.c
@@ -22,6 +22,7 @@
 #include "so3_types.h"
 #include "so3_error.h"
 #include "so3_sampling.h"
+#include "so3_core.h"
 
 #define MIN(a,b) ((a < b) ? (a) : (b))
 #define MAX(a,b) ((a > b) ? (a) : (b))
@@ -954,23 +955,19 @@ void so3_core_inverse_direct(
 ) {
 
     int L0, L, N;
-    so3_sampling_t sampling;
     so3_storage_t storage;
     so3_n_mode_t n_mode;
     ssht_dl_method_t dl_method;
-    int steerable;
     int verbosity;
 
     L0 = parameters->L0;
     L = parameters->L;
     N = parameters->N;
-    sampling = parameters->sampling_scheme;
     storage = parameters->storage;
     // TODO: Add optimisations for all n-modes.
     n_mode = parameters->n_mode;
     dl_method = parameters->dl_method;
     verbosity = parameters->verbosity;
-    steerable = parameters->steerable;
 
     // Print messages depending on verbosity level.
     if (verbosity > 0)
@@ -993,7 +990,7 @@ void so3_core_inverse_direct(
     SO3_ERROR_MEM_ALLOC_CHECK(signs);
     complex double *exps = calloc(4, sizeof(*exps));
     SO3_ERROR_MEM_ALLOC_CHECK(exps);
-  
+
     // Perform precomputations.
     for (el = 0; el <= 2*L-1; ++el)
         sqrt_tbl[el] = sqrt((double)el);
@@ -1046,16 +1043,16 @@ void so3_core_inverse_direct(
         switch (dl_method)
         {
         case SSHT_DL_RISBO:
-            if (el != 0 && el == L0) 
+            if (el != 0 && el == L0)
             {
                 for(eltmp = 0; eltmp <= L0; ++eltmp)
                     ssht_dl_beta_risbo_eighth_table(
-                            dl8, 
-                            SO3_PION2, 
+                            dl8,
+                            SO3_PION2,
                             L,
                             SSHT_DL_QUARTER_EXTENDED,
-                            eltmp, 
-                            sqrt_tbl, 
+                            eltmp,
+                            sqrt_tbl,
                             signs);
                 ssht_dl_beta_risbo_fill_eighth2quarter_table(dl,
                         dl8, L,
@@ -1063,16 +1060,16 @@ void so3_core_inverse_direct(
                         SSHT_DL_QUARTER_EXTENDED,
                         el,
                         signs);
-            } 
-            else 
+            }
+            else
             {
                 ssht_dl_beta_risbo_eighth_table(
-                        dl8, 
-                        SO3_PION2, 
+                        dl8,
+                        SO3_PION2,
                         L,
                         SSHT_DL_QUARTER_EXTENDED,
-                        el, 
-                        sqrt_tbl, 
+                        el,
+                        sqrt_tbl,
                         signs);
                 ssht_dl_beta_risbo_fill_eighth2quarter_table(
                         dl,
@@ -1085,35 +1082,35 @@ void so3_core_inverse_direct(
             break;
 
         case SSHT_DL_TRAPANI:
-            if (el != 0 && el == L0) 
+            if (el != 0 && el == L0)
             {
                 for(eltmp = 0; eltmp <= L0; ++eltmp)
                     ssht_dl_halfpi_trapani_eighth_table(
-                            dl, 
+                            dl,
                             L,
                             SSHT_DL_QUARTER,
-                            eltmp, 
+                            eltmp,
                             sqrt_tbl);
                 ssht_dl_halfpi_trapani_fill_eighth2quarter_table(
-                        dl, 
+                        dl,
                         L,
                         SSHT_DL_QUARTER,
-                        el, 
+                        el,
                         signs);
             }
             else
             {
                 ssht_dl_halfpi_trapani_eighth_table(
-                        dl, 
+                        dl,
                         L,
                         SSHT_DL_QUARTER,
-                        el, 
+                        el,
                         sqrt_tbl);
                 ssht_dl_halfpi_trapani_fill_eighth2quarter_table(
-                        dl, 
+                        dl,
                         L,
                         SSHT_DL_QUARTER,
-                        el, 
+                        el,
                         signs);
             }
             break;
@@ -1196,7 +1193,7 @@ void so3_core_inverse_direct(
                     Fmnm[m + m_offset + m_stride*(
                          n + n_offset + n_stride*(
                          mm + mm_offset))] +=
-                        elnmm_factor 
+                        elnmm_factor
                         * mn_factors[m + m_offset + m_stride*(
                                      n + n_offset)]
                         * elmmsign * dl[-m + dl_offset + mm*dl_stride];
@@ -1204,7 +1201,7 @@ void so3_core_inverse_direct(
                     Fmnm[m + m_offset + m_stride*(
                          n + n_offset + n_stride*(
                          mm + mm_offset))] +=
-                        elnmm_factor 
+                        elnmm_factor
                         * mn_factors[m + m_offset + m_stride*(
                                      n + n_offset)]
                         * dl[m + dl_offset + mm*dl_stride];
@@ -1274,9 +1271,9 @@ void so3_core_inverse_direct(
 
     // Set up plan before initialising array.
     fftw_plan plan = fftw_plan_dft_3d(
-                        2*N-1, 2*L-1, 2*L-1, 
+                        2*N-1, 2*L-1, 2*L-1,
                         fext, fext,
-                        FFTW_BACKWARD, 
+                        FFTW_BACKWARD,
                         FFTW_ESTIMATE);
 
     // Apply spatial shift.
@@ -1356,23 +1353,19 @@ void so3_core_forward_direct(
     const so3_parameters_t *parameters
 ) {
     int L0, L, N;
-    so3_sampling_t sampling;
     so3_storage_t storage;
     so3_n_mode_t n_mode;
     ssht_dl_method_t dl_method;
-    int steerable;
     int verbosity;
 
     L0 = parameters->L0;
     L = parameters->L;
     N = parameters->N;
-    sampling = parameters->sampling_scheme;
     storage = parameters->storage;
     // TODO: Add optimisations for all n-modes.
     n_mode = parameters->n_mode;
     dl_method = parameters->dl_method;
     verbosity = parameters->verbosity;
-    steerable = parameters->steerable;
 
     // Print messages depending on verbosity level.
     if (verbosity > 0) {
@@ -1457,8 +1450,8 @@ void so3_core_forward_direct(
     SO3_ERROR_MEM_ALLOC_CHECK(inout);
     fftw_plan plan = fftw_plan_dft_2d(
                         2*N-1, 2*L-1,
-                        inout, inout, 
-                        FFTW_FORWARD, 
+                        inout, inout,
+                        FFTW_FORWARD,
                         FFTW_ESTIMATE);
 
     int b, g;
@@ -1469,10 +1462,10 @@ void so3_core_forward_direct(
         // over the 1st and 3rd dimensions of f.
         for (g = 0; g < 2*N-1; ++g)
             memcpy(
-                inout + g*a_stride, 
+                inout + g*a_stride,
                 f + 0 + a_stride*(
                     b + b_stride*(
-                    g)), 
+                    g)),
                 a_stride*sizeof(*f));
         fftw_execute_dft(plan, inout, inout);
 
@@ -1515,16 +1508,16 @@ void so3_core_forward_direct(
 
     plan = fftw_plan_dft_1d(
             2*L-1,
-            inout, inout, 
-            FFTW_FORWARD, 
+            inout, inout,
+            FFTW_FORWARD,
             FFTW_ESTIMATE);
     for (n = n_start; n <= n_stop; n += n_inc)
         for (m = -L+1; m <= L-1; ++m)
         {
-            memcpy(inout, 
+            memcpy(inout,
                    Fmnb + 0 + bext_stride*(
                           m + m_offset + m_stride*(
-                          n + n_offset)), 
+                          n + n_offset)),
                    bext_stride*sizeof(*Fmnb));
             fftw_execute_dft(plan, inout, inout);
 
@@ -1563,15 +1556,15 @@ void so3_core_forward_direct(
     inout = calloc(4*L-3, sizeof(*inout));
     SO3_ERROR_MEM_ALLOC_CHECK(inout);
     fftw_plan plan_bwd = fftw_plan_dft_1d(
-                            4*L-3, 
-                            inout, inout, 
-                            FFTW_BACKWARD, 
+                            4*L-3,
+                            inout, inout,
+                            FFTW_BACKWARD,
                             FFTW_MEASURE);
     fftw_plan plan_fwd = fftw_plan_dft_1d(
-                            4*L-3, 
-                            inout, 
-                            inout, 
-                            FFTW_FORWARD, 
+                            4*L-3,
+                            inout,
+                            inout,
+                            FFTW_FORWARD,
                             FFTW_MEASURE);
 
     // Apply spatial shift.
@@ -1607,7 +1600,7 @@ void so3_core_forward_direct(
                     Fmnm[mm + mm_offset + mm_stride*(
                          m + m_offset + m_stride*(
                          n + n_offset))];
-        
+
             // Apply spatial shift.
             for (mm = 1; mm <= 2*L-2; ++mm)
                 inout[mm + w_offset] = Fmnm_pad[mm - 2*(L-1) - 1 + w_offset];
@@ -1620,12 +1613,12 @@ void so3_core_forward_direct(
                 Fmnm_pad[mm + w_offset] = inout[mm - 2*(L-1) + w_offset];
             for (mm = -2*(L-1); mm <= -1; ++mm)
                 Fmnm_pad[mm + w_offset] = inout[mm + 2*(L-1) + 1 + w_offset];
-        
+
             // Compute product of Fmnm' and weight in real space.
             int r;
             for (r = -2*(L-1); r <= 2*(L-1); ++r)
                 Fmnm_pad[r + w_offset] *= wr[r + w_offset];
-        
+
             // Apply spatial shift.
             for (mm = 1; mm <= 2*L-2; ++mm)
                 inout[mm + w_offset] = Fmnm_pad[mm - 2*(L-1) - 1 + w_offset];
@@ -1638,15 +1631,15 @@ void so3_core_forward_direct(
                 Fmnm_pad[mm + w_offset] = inout[mm - 2*(L-1) + w_offset];
             for (mm = -2*(L-1); mm <= -1; ++mm)
                 Fmnm_pad[mm + w_offset] = inout[mm + 2*(L-1) + 1 + w_offset];
-        
+
             // Extract section of Gmnm' of interest.
             for (mm = -(L-1); mm <= L-1; ++mm)
                 Gmnm[m + m_offset + m_stride*(
                      mm + mm_offset + mm_stride*(
                      n + n_offset))] =
-                    Fmnm_pad[mm + w_offset] 
+                    Fmnm_pad[mm + w_offset]
                     * 4.0 * SSHT_PI * SSHT_PI / (4.0*L-3.0);
-        
+
         }
     fftw_destroy_plan(plan_bwd);
     fftw_destroy_plan(plan_fwd);
@@ -1772,7 +1765,7 @@ void so3_core_forward_direct(
         default:
             SO3_ERROR_GENERIC("Invalid n-mode.");
         }
-    
+
         // TODO: Pull out a few multiplications into precomputations
         // or split up loops to avoid conditionals to check signs.
         for (mm = -el; mm <= el; ++mm)
@@ -1785,11 +1778,11 @@ void so3_core_forward_direct(
             {
                 double mmsign = mm >= 0 ? 1.0 : signs[el] * signs[abs(n)];
                 double elnsign = n >= 0 ? 1.0 : elmmsign;
-                 
+
                 // Factor which does not depend on m.
                 double elnmm_factor = mmsign * elnsign
                                       * dl[abs(n) + dl_offset + abs(mm)*dl_stride];
-                
+
                 for (m = -el; m <= el; ++m)
                 {
                     mmsign = mm >= 0 ? 1.0 : signs[el] * signs[abs(m)];
@@ -1797,7 +1790,7 @@ void so3_core_forward_direct(
                     int ind;
                     so3_sampling_elmn2ind(&ind, el, m, n, parameters);
                     int mod = ((m-n)%4 + 4)%4;
-                    flmn[ind] += 
+                    flmn[ind] +=
                         exps[mod]
                         * elnmm_factor
                         * mmsign * elmsign
@@ -1853,23 +1846,19 @@ void so3_core_inverse_direct_real(
 ) {
 
     int L0, L, N;
-    so3_sampling_t sampling;
     so3_storage_t storage;
     so3_n_mode_t n_mode;
     ssht_dl_method_t dl_method;
-    int steerable;
     int verbosity;
 
     L0 = parameters->L0;
     L = parameters->L;
     N = parameters->N;
-    sampling = parameters->sampling_scheme;
     storage = parameters->storage;
     // TODO: Add optimisations for all n-modes.
     n_mode = parameters->n_mode;
     dl_method = parameters->dl_method;
     verbosity = parameters->verbosity;
-    steerable = parameters->steerable;
 
     // Print messages depending on verbosity level.
     if (verbosity > 0)
@@ -1892,7 +1881,7 @@ void so3_core_inverse_direct_real(
     SO3_ERROR_MEM_ALLOC_CHECK(signs);
     complex double *exps = calloc(4, sizeof(*exps));
     SO3_ERROR_MEM_ALLOC_CHECK(exps);
-  
+
     // Perform precomputations.
     for (el = 0; el <= 2*L-1; ++el)
         sqrt_tbl[el] = sqrt((double)el);
@@ -1945,16 +1934,16 @@ void so3_core_inverse_direct_real(
         switch (dl_method)
         {
         case SSHT_DL_RISBO:
-            if (el != 0 && el == L0) 
+            if (el != 0 && el == L0)
             {
                 for(eltmp = 0; eltmp <= L0; ++eltmp)
                     ssht_dl_beta_risbo_eighth_table(
-                            dl8, 
-                            SO3_PION2, 
+                            dl8,
+                            SO3_PION2,
                             L,
                             SSHT_DL_QUARTER_EXTENDED,
-                            eltmp, 
-                            sqrt_tbl, 
+                            eltmp,
+                            sqrt_tbl,
                             signs);
                 ssht_dl_beta_risbo_fill_eighth2quarter_table(dl,
                         dl8, L,
@@ -1962,16 +1951,16 @@ void so3_core_inverse_direct_real(
                         SSHT_DL_QUARTER_EXTENDED,
                         el,
                         signs);
-            } 
-            else 
+            }
+            else
             {
                 ssht_dl_beta_risbo_eighth_table(
-                        dl8, 
-                        SO3_PION2, 
+                        dl8,
+                        SO3_PION2,
                         L,
                         SSHT_DL_QUARTER_EXTENDED,
-                        el, 
-                        sqrt_tbl, 
+                        el,
+                        sqrt_tbl,
                         signs);
                 ssht_dl_beta_risbo_fill_eighth2quarter_table(
                         dl,
@@ -1984,35 +1973,35 @@ void so3_core_inverse_direct_real(
             break;
 
         case SSHT_DL_TRAPANI:
-            if (el != 0 && el == L0) 
+            if (el != 0 && el == L0)
             {
                 for(eltmp = 0; eltmp <= L0; ++eltmp)
                     ssht_dl_halfpi_trapani_eighth_table(
-                            dl, 
+                            dl,
                             L,
                             SSHT_DL_QUARTER,
-                            eltmp, 
+                            eltmp,
                             sqrt_tbl);
                 ssht_dl_halfpi_trapani_fill_eighth2quarter_table(
-                        dl, 
+                        dl,
                         L,
                         SSHT_DL_QUARTER,
-                        el, 
+                        el,
                         signs);
             }
             else
             {
                 ssht_dl_halfpi_trapani_eighth_table(
-                        dl, 
+                        dl,
                         L,
                         SSHT_DL_QUARTER,
-                        el, 
+                        el,
                         sqrt_tbl);
                 ssht_dl_halfpi_trapani_fill_eighth2quarter_table(
-                        dl, 
+                        dl,
                         L,
                         SSHT_DL_QUARTER,
-                        el, 
+                        el,
                         signs);
             }
             break;
@@ -2091,7 +2080,7 @@ void so3_core_inverse_direct_real(
                     Fmnm[m + m_offset + m_stride*(
                          n + n_offset + n_stride*(
                          mm + mm_offset))] +=
-                        elnmm_factor 
+                        elnmm_factor
                         * mn_factors[m + m_offset + m_stride*(
                                      n + n_offset)]
                         * elmmsign * dl[-m + dl_offset + mm*dl_stride];
@@ -2099,7 +2088,7 @@ void so3_core_inverse_direct_real(
                     Fmnm[m + m_offset + m_stride*(
                          n + n_offset + n_stride*(
                          mm + mm_offset))] +=
-                        elnmm_factor 
+                        elnmm_factor
                         * mn_factors[m + m_offset + m_stride*(
                                      n + n_offset)]
                         * dl[m + dl_offset + mm*dl_stride];
@@ -2257,23 +2246,19 @@ void so3_core_forward_direct_real(
     const so3_parameters_t *parameters
 ) {
     int L0, L, N;
-    so3_sampling_t sampling;
     so3_storage_t storage;
     so3_n_mode_t n_mode;
     ssht_dl_method_t dl_method;
-    int steerable;
     int verbosity;
 
     L0 = parameters->L0;
     L = parameters->L;
     N = parameters->N;
-    sampling = parameters->sampling_scheme;
     storage = parameters->storage;
     // TODO: Add optimisations for all n-modes.
     n_mode = parameters->n_mode;
     dl_method = parameters->dl_method;
     verbosity = parameters->verbosity;
-    steerable = parameters->steerable;
 
     // Print messages depending on verbosity level.
     if (verbosity > 0) {
@@ -2423,19 +2408,19 @@ void so3_core_forward_direct_real(
     SO3_ERROR_MEM_ALLOC_CHECK(Fmnm);
     complex double *inout = calloc(2*L-1, sizeof(*inout));
     SO3_ERROR_MEM_ALLOC_CHECK(inout);
-    
+
     plan = fftw_plan_dft_1d(
             2*L-1,
-            inout, inout, 
-            FFTW_FORWARD, 
+            inout, inout,
+            FFTW_FORWARD,
             FFTW_ESTIMATE);
     for (n = n_start; n <= n_stop; n += n_inc)
         for (m = -L+1; m <= L-1; ++m)
         {
-            memcpy(inout, 
+            memcpy(inout,
                    Fmnb + 0 + bext_stride*(
                           m + m_offset + m_stride*(
-                          n + n_offset)), 
+                          n + n_offset)),
                    bext_stride*sizeof(*Fmnb));
             fftw_execute(plan);
 
@@ -2474,15 +2459,15 @@ void so3_core_forward_direct_real(
     inout = calloc(4*L-3, sizeof(*inout));
     SO3_ERROR_MEM_ALLOC_CHECK(inout);
     fftw_plan plan_bwd = fftw_plan_dft_1d(
-                            4*L-3, 
-                            inout, inout, 
-                            FFTW_BACKWARD, 
+                            4*L-3,
+                            inout, inout,
+                            FFTW_BACKWARD,
                             FFTW_MEASURE);
     fftw_plan plan_fwd = fftw_plan_dft_1d(
-                            4*L-3, 
-                            inout, 
-                            inout, 
-                            FFTW_FORWARD, 
+                            4*L-3,
+                            inout,
+                            inout,
+                            FFTW_FORWARD,
                             FFTW_MEASURE);
 
     // Apply spatial shift.
@@ -2518,7 +2503,7 @@ void so3_core_forward_direct_real(
                     Fmnm[mm + mm_offset + mm_stride*(
                          m + m_offset + m_stride*(
                          n + n_offset))];
-        
+
             // Apply spatial shift.
             for (mm = 1; mm <= 2*L-2; ++mm)
                 inout[mm + w_offset] = Fmnm_pad[mm - 2*(L-1) - 1 + w_offset];
@@ -2531,12 +2516,12 @@ void so3_core_forward_direct_real(
                 Fmnm_pad[mm + w_offset] = inout[mm - 2*(L-1) + w_offset];
             for (mm = -2*(L-1); mm <= -1; ++mm)
                 Fmnm_pad[mm + w_offset] = inout[mm + 2*(L-1) + 1 + w_offset];
-        
+
             // Compute product of Fmnm' and weight in real space.
             int r;
             for (r = -2*(L-1); r <= 2*(L-1); ++r)
                 Fmnm_pad[r + w_offset] *= wr[r + w_offset];
-        
+
             // Apply spatial shift.
             for (mm = 1; mm <= 2*L-2; ++mm)
                 inout[mm + w_offset] = Fmnm_pad[mm - 2*(L-1) - 1 + w_offset];
@@ -2549,15 +2534,15 @@ void so3_core_forward_direct_real(
                 Fmnm_pad[mm + w_offset] = inout[mm - 2*(L-1) + w_offset];
             for (mm = -2*(L-1); mm <= -1; ++mm)
                 Fmnm_pad[mm + w_offset] = inout[mm + 2*(L-1) + 1 + w_offset];
-        
+
             // Extract section of Gmnm' of interest.
             for (mm = -(L-1); mm <= L-1; ++mm)
                 Gmnm[m + m_offset + m_stride*(
                      mm + mm_offset + mm_stride*(
                      n + n_offset))] =
-                    Fmnm_pad[mm + w_offset] 
+                    Fmnm_pad[mm + w_offset]
                     * 4.0 * SSHT_PI * SSHT_PI / (4.0*L-3.0);
-        
+
         }
     fftw_destroy_plan(plan_bwd);
     fftw_destroy_plan(plan_fwd);
@@ -2682,7 +2667,7 @@ void so3_core_forward_direct_real(
         default:
             SO3_ERROR_GENERIC("Invalid n-mode.");
         }
-    
+
         // TODO: Pull out a few multiplications into precomputations
         // or split up loops to avoid conditionals to check signs.
         for (mm = -el; mm <= el; ++mm)
@@ -2694,11 +2679,11 @@ void so3_core_forward_direct_real(
             for (n = n_start; n <= n_stop; n += n_inc)
             {
                 double mmsign = mm >= 0 ? 1.0 : signs[el] * signs[n];
-                 
+
                 // Factor which does not depend on m.
                 double elnmm_factor = mmsign
                                       * dl[n + dl_offset + abs(mm)*dl_stride];
-                
+
                 for (m = -el; m <= el; ++m)
                 {
                     mmsign = mm >= 0 ? 1.0 : signs[el] * signs[abs(m)];
@@ -2706,7 +2691,7 @@ void so3_core_forward_direct_real(
                     int ind;
                     so3_sampling_elmn2ind_real(&ind, el, m, n, parameters);
                     int mod = ((m-n)%4 + 4)%4;
-                    flmn[ind] += 
+                    flmn[ind] +=
                         exps[mod]
                         * elnmm_factor
                         * mmsign * elmsign

--- a/src/c/so3_error.h
+++ b/src/c/so3_error.h
@@ -21,7 +21,7 @@
   printf("ERROR: %s.\n", comment);					\
   printf("ERROR: %s <%s> %s %s %s %d.\n",				\
 	 "Occurred in function",					\
-	   __PRETTY_FUNCTION__,						\
+	   __func__,						\
 	   "of file", __FILE__,						\
 	   "on line", __LINE__);					\
   exit(1);                                                              \

--- a/src/c/so3_sampling.c
+++ b/src/c/so3_sampling.c
@@ -7,6 +7,7 @@
 #include <math.h>
 #include "so3_error.h"
 #include "so3_types.h"
+#include "so3_sampling.h"
 
 int so3_sampling_nalpha(const so3_parameters_t *);
 int so3_sampling_nbeta(const so3_parameters_t *);
@@ -28,7 +29,7 @@ int so3_sampling_ngamma(const so3_parameters_t *);
  * \author <a href="http://www.jasonmcewen.org">Jason McEwen</a>
  */
 complex double so3_sampling_weight(
-    const so3_parameters_t *parameters, 
+    const so3_parameters_t *parameters,
     int p)
 {
     switch (parameters->sampling_scheme)
@@ -77,10 +78,6 @@ complex double so3_sampling_weight(
  */
 int so3_sampling_f_size(const so3_parameters_t *parameters)
 {
-    int L, N;
-    L = parameters->L;
-    N = parameters->N;
-
     return so3_sampling_nalpha(parameters) *
            so3_sampling_nbeta(parameters) *
            so3_sampling_ngamma(parameters);
@@ -109,9 +106,8 @@ int so3_sampling_f_size(const so3_parameters_t *parameters)
  */
 int so3_sampling_n(const so3_parameters_t *parameters)
 {
-    int L, N;
+    int L;
     L = parameters->L;
-    N = parameters->N;
 
     // Are these actually correct?
     switch (parameters->sampling_scheme)

--- a/src/c/so3_sampling.h
+++ b/src/c/so3_sampling.h
@@ -19,12 +19,10 @@ double so3_sampling_a2alpha(int a, const so3_parameters_t *parameters);
 double so3_sampling_b2beta(int b, const so3_parameters_t *parameters);
 double so3_sampling_g2gamma(int g, const so3_parameters_t *parameters);
 
-// Note, if this is compiled using C99-standard then the "extern" belongs in the
-// .c file instead.
-extern inline int so3_sampling_flmn_size(const so3_parameters_t *parameters);
-extern inline void so3_sampling_elmn2ind(int *ind, int el, int m, int n, const so3_parameters_t *parameters);
-extern inline void so3_sampling_ind2elmn(int *el, int *m, int *n, int ind, const so3_parameters_t *parameters);
-extern inline void so3_sampling_elmn2ind_real(int *ind, int el, int m, int n, const so3_parameters_t *parameters);
-extern inline void so3_sampling_ind2elmn_real(int *el, int *m, int *n, int ind, const so3_parameters_t *parameters);
+int so3_sampling_flmn_size(const so3_parameters_t *parameters);
+void so3_sampling_elmn2ind(int *ind, int el, int m, int n, const so3_parameters_t *parameters);
+void so3_sampling_ind2elmn(int *el, int *m, int *n, int ind, const so3_parameters_t *parameters);
+void so3_sampling_elmn2ind_real(int *ind, int el, int m, int n, const so3_parameters_t *parameters);
+void so3_sampling_ind2elmn_real(int *el, int *m, int *n, int ind, const so3_parameters_t *parameters);
 
 #endif

--- a/src/c/so3_test.c
+++ b/src/c/so3_test.c
@@ -44,7 +44,7 @@ void so3_test_gen_flmn_real(complex double *flmn, const so3_parameters_t *parame
 
 int main(int argc, char **argv)
 {
-    so3_parameters_t parameters = {};
+    so3_parameters_t parameters = {0};
     int L, N, L0;
     complex double *flmn_orig, *flmn_syn;
     complex double *f;

--- a/src/c/so3_test_csv.c
+++ b/src/c/so3_test_csv.c
@@ -54,7 +54,7 @@ void so3_test_gen_flmn_real(complex double *flmn, const so3_parameters_t *parame
 
 int main(int argc, char **argv)
 {
-    so3_parameters_t parameters = {};
+    so3_parameters_t parameters = {0};
     int Lmax, L, useLasN, N, L0;
     complex double *flmn_orig, *flmn_syn;
     complex double *f;
@@ -64,34 +64,11 @@ int main(int argc, char **argv)
     int i, real;
     int flmn_size;
 
-    const char *n_order_str[SO3_N_ORDER_SIZE];
-    const char *storage_mode_str[SO3_STORAGE_SIZE];
-    const char *n_mode_str[SO3_N_MODE_SIZE];
-    const char *reality_str[2];
-    const char *sampling_str[2];
-
     double min_duration_inverse;
     double min_duration_forward;
     double avg_duration_inverse;
     double avg_duration_forward;
     double avg_error;
-
-    n_order_str[SO3_N_ORDER_ZERO_FIRST] = "n = 0 first";
-    n_order_str[SO3_N_ORDER_NEGATIVE_FIRST] = "n = -N+1 first";
-
-    storage_mode_str[SO3_STORAGE_PADDED] = "padded storage";
-    storage_mode_str[SO3_STORAGE_COMPACT] = "compact storage";
-
-    n_mode_str[SO3_N_MODE_ALL] = "all n";
-    n_mode_str[SO3_N_MODE_EVEN] = "only even n";
-    n_mode_str[SO3_N_MODE_ODD] = "only odd n";
-    n_mode_str[SO3_N_MODE_MAXIMUM] = "only |n| = N-1";
-
-    reality_str[0] = "complex";
-    reality_str[1] = "real";
-
-    sampling_str[0] = "MW";
-    sampling_str[1] = "MWSS";
 
     // Parse command line arguments
     N = Lmax = 64;

--- a/src/c/unittest/so3_unittest.c
+++ b/src/c/unittest/so3_unittest.c
@@ -5,12 +5,12 @@
 #include "../so3_types.h"
 #include "../so3_sampling.h"
 
-static void test_sampling_elmn2ind();
-static void test_sampling_ind2elmn();
-static void test_sampling_elmn2ind_real();
-static void test_sampling_ind2elmn_real();
+static void test_sampling_elmn2ind(void);
+static void test_sampling_ind2elmn(void);
+static void test_sampling_elmn2ind_real(void);
+static void test_sampling_ind2elmn_real(void);
 
-int main() {
+int main(void) {
     test_sampling_elmn2ind();
     test_sampling_ind2elmn();
     test_sampling_elmn2ind_real();
@@ -19,9 +19,9 @@ int main() {
     return 0;
 }
 
-void test_sampling_elmn2ind()
+static void test_sampling_elmn2ind()
 {
-    so3_parameters_t parameters = {};
+    so3_parameters_t parameters = {0};
     int ind;
 
     // Test padded storage with n-order 0, -1, 1, -2, 2, ...
@@ -177,9 +177,9 @@ void test_sampling_elmn2ind()
             "Element (2,1,2) in wrong position for L = N = 3." );
 }
 
-void test_sampling_ind2elmn()
+static void test_sampling_ind2elmn()
 {
-    so3_parameters_t parameters = {};
+    so3_parameters_t parameters = {0};
     int el, m, n;
 
     // Test padded storage with n-order 0, -1, 1, -2, 2, ...
@@ -335,9 +335,9 @@ void test_sampling_ind2elmn()
             "Index 33 yields wrong indices (el,m,n)." );
 }
 
-void test_sampling_elmn2ind_real()
+static void test_sampling_elmn2ind_real()
 {
-    so3_parameters_t parameters = {};
+    so3_parameters_t parameters = {0};
     int ind;
 
     // Test padded storage for a real signal (n-order 0, 1, 2, ...)
@@ -396,9 +396,9 @@ void test_sampling_elmn2ind_real()
             "Element (2,1,2) in wrong position for L = 3." );
 }
 
-void test_sampling_ind2elmn_real()
+static void test_sampling_ind2elmn_real()
 {
-    so3_parameters_t parameters = {};
+    so3_parameters_t parameters = {0};
     int el, m, n;
 
     // Test padded storage for a real signal (n-order 0, 1, 2, ...)

--- a/src/matlab/so3_elmn2ind_mex.c
+++ b/src/matlab/so3_elmn2ind_mex.c
@@ -27,7 +27,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
     char order[SO3_STRING_LEN], storage[SO3_STRING_LEN];
     int reality;
 
-    so3_parameters_t parameters = {};
+    so3_parameters_t parameters = {0};
 
     /* Check number of arguments */
     if (nrhs != 8)

--- a/src/matlab/so3_forward_direct_mex.c
+++ b/src/matlab/so3_forward_direct_mex.c
@@ -40,7 +40,7 @@
     ssht_dl_method_t dl_method;
     so3_sampling_t sampling_scheme;
 
-    so3_parameters_t parameters = {};
+    so3_parameters_t parameters = {0};
 
     int reality;
 

--- a/src/matlab/so3_forward_mex.c
+++ b/src/matlab/so3_forward_mex.c
@@ -40,7 +40,7 @@
     ssht_dl_method_t dl_method;
     so3_sampling_t sampling_scheme;
 
-    so3_parameters_t parameters = {};
+    so3_parameters_t parameters = {0};
 
     int reality;
 

--- a/src/matlab/so3_ind2elmn_mex.c
+++ b/src/matlab/so3_ind2elmn_mex.c
@@ -27,7 +27,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
     char order[SO3_STRING_LEN], storage[SO3_STRING_LEN];
     int reality;
 
-    so3_parameters_t parameters = {};
+    so3_parameters_t parameters = {0};
 
     /* Check number of arguments */
     if (nrhs != 6)

--- a/src/matlab/so3_inverse_direct_mex.c
+++ b/src/matlab/so3_inverse_direct_mex.c
@@ -37,7 +37,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
     ssht_dl_method_t dl_method;
     so3_sampling_t sampling_scheme;
 
-    so3_parameters_t parameters = {};
+    so3_parameters_t parameters = {0};
 
     int reality;
 

--- a/src/matlab/so3_inverse_mex.c
+++ b/src/matlab/so3_inverse_mex.c
@@ -37,7 +37,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
     ssht_dl_method_t dl_method;
     so3_sampling_t sampling_scheme;
 
-    so3_parameters_t parameters = {};
+    so3_parameters_t parameters = {0};
 
     int reality;
 


### PR DESCRIPTION
Same as for ssht and s2let: this makes the sources conform to C99 and fixes many compiler warnings.